### PR TITLE
Additional information for file name normalization

### DIFF
--- a/src/fileNamer.js
+++ b/src/fileNamer.js
@@ -10,11 +10,12 @@ const categoryMap = {
   '1': 'ImpotsRevenus',
   '2': 'TaxeFoncière',
   '3': 'TaxeHabitation',
+  '4': 'PrélèvementsSociaux',
   '5': 'RedevanceAudiovisuelle'
 }
 
 const documentTypeMap = {
-  '1': 'Formulaire',
+  '1': 'FormulaireEnLigne',
   '2': 'Avis',
   '4': 'AccuséRéception',
   '5': 'Formulaire',
@@ -22,13 +23,17 @@ const documentTypeMap = {
 }
 
 const formTypeMap = {
+  '1': 'Primitif',
   '2': 'Correctif',
+  '3': 'Dégrèvement',
   '4': 'Suite',
   '71': 'Echeancier',
+  '811': 'PremierAcompte',
+  '812': 'SecondAcompte',
   AR: false,
   '1MEN': 'Primitif',
   '1ASDIR': 'SituationDéclarative',
-  '1TIP': false
+  '1TIP': 'PrimitifPrélevé'
 }
 
 function normalizeFileNames(documents) {


### PR DESCRIPTION
New parameters and mapping to normalize the impots file name.

I left out the renaming of "Formulaire" into "Déclaration", waiting for project confirmation.

Also, I did **not** change '1MEN' from "Primitif" to "PrimitifMensualisé" as it's just an hypothesis of mine, I have no real-world example to confirm it.

Both can be done later after discussion.

---
Nouveaux paramètres et correspondances pour la normalisation du nommage des fichiers impôts.

J'ai mis de côté le renommage de "Formulaire" en "Déclaration", attendant la confirmation de @LucsT pour cela.

Par ailleurs, je n'ai **pas** changé  '1MEN' de "Primitif" à "PrimitifMensualisé" car il s'agit juste d'une hypothèse, je n'ai pas de cas concret pour le vérifier.

Cela peut être fait ultérieurement après discussion.