### PR TITLE
New getDocuments function on new interface, and dummy log commit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ async function start(fields) {
     contentType: 'application/pdf'
   })
   try {
+    log('info', 'Fetching identity ...')
     const ident = await fetchIdentity()
     await this.saveIdentity(ident, fields.login)
   } catch (e) {


### PR DESCRIPTION
@doubleface for a quick review and an approve 

@edas, @ptbrowne  for info

Add the async function getDocuments that scrape available year then scrape files available in a clean way.
Eslint disable for now on one line, because linter didn't allow the function to not be used in code.

Return an array of objects that can be pass to saveFiles : 
```
{ year: '2019',
  label: 'Avis d\'impôt 2019 sur les revenus et prélèvements sociaux 2018',
  idEnsua: '26D27B3B9E777EC49337BBCFBBBBBBBBBBBBBFE5C572252AAAAAAAAAAAAA',
  filename: 'Avis d\'impôt 2019 sur les revenus et prélèvements sociaux 2018.pdf',
  fileurl: 'https://cfspart.impots.gouv.fr/enp/ensu/Affichage_Document_PDF?idEnsua=26D27B3B9REDACTEDE7E3716',
}
```

Another commit add one line of log for more readability.


That can be merge to master as soon as it's ok. I will rebase on this for next step on some new branches.
