### PR TITLE
feat: Add a new fileNamer to eval old name, and a matching comparaison

### DIFF
--- a/src/fileNamer.js
+++ b/src/fileNamer.js
@@ -5,7 +5,7 @@ const moment = require('moment')
 // normalize the impots file names with the following format
 // "year-category-docType-formType-adonisNumber.pdf"
 // ex: 2016-ImpotsRevenus-Avis-SituationDéclarative-3938943793797.pdf
-module.exports = normalizeFileNames
+module.exports = { normalizeFileNames, evaluateNewLabel }
 
 const categoryMap = {
   '1': 'ImpotsRevenus',
@@ -150,4 +150,140 @@ function mapValue(map, value) {
   } else {
     return `-${map[value]}`
   }
+}
+
+function evaluateNewLabel(documents, L, LWP) {
+  let failed = 0
+  for (let doc of documents) {
+    doc.category = evalCategory(doc)
+    if (doc.category === undefined) {
+      if (LWP) {
+        log('info', `New label: ${doc.label}`)
+      }
+      log('warn', 'Category Unknown')
+      failed++
+      continue
+      //throw 'Category Unknown'
+    }
+    doc.type = evalType(doc)
+    if (doc.type === undefined) {
+      if (LWP) {
+        log('info', `New label: ${doc.label}`)
+      }
+      log('warn', 'Type Unknown')
+      failed++
+      continue
+      //throw 'Type Unknown'
+    }
+    doc.form = evalForm(doc, doc.year, doc.category)
+    if (doc.form === undefined) {
+      if (LWP) {
+        log('info', `New label: ${doc.label}`)
+      }
+      log('warn', 'Form Unknown')
+      failed++
+      continue
+      //throw 'Form Unknown'
+    }
+
+    doc.oldname =
+      `${doc.year}-${doc.category}-${doc.type}` +
+      (doc.form === '' ? '-' : `-${doc.form}-`)
+    if (LWP) {
+      log('info', '-----')
+      log('info', `New label: ${doc.label}`)
+      log('info', `Old name prediction: ${doc.oldname}`)
+      log('info', '-----')
+    }
+  }
+  log(
+    'info',
+    `Failed category, type or form evaluation: ${failed} on ${documents.length}`
+  )
+  log('info', `#Failed#: ${((100 * failed) / documents.length).toFixed(2)}%`)
+  return documents
+}
+
+function evalCategory(doc) {
+  if (doc.label.match(/revenus/)) {
+    return 'ImpotsRevenus'
+  } else if (doc.label.match(/habitation/)) {
+    return 'TaxeHabitation'
+  } else if (doc.label.match(/foncières/)) {
+    return 'TaxeFoncière'
+  } else if (doc.label.match(/RedevanceAudiovisuelle/)) {
+    // WARNING, NEVER ENCOUNTERED
+    return 'RedevanceAudiovisuelle'
+  } else {
+    return undefined
+  }
+}
+
+function evalType(doc) {
+  if (
+    doc.label.match(/^Avis d'impôt/) ||
+    doc.label.match(/^Avis de/) ||
+    doc.label.match(/^1er Avis/) ||
+    doc.label.match(/^2e Avis/) ||
+    doc.label.match(/^Avis échéancier/)
+  ) {
+    return 'Avis'
+  } else if (
+    doc.label.match(/^Déclaration en ligne/) ||
+    doc.label.match(/^Déclaration complémentaire/) ||
+    doc.label.match(/^Déclaration/) // recoupe les 2 autres
+  ) {
+    return 'Formulaire'
+  } else if (doc.label.match(/^Accusé de réception/)) {
+    return 'AccuséRéception'
+  } else {
+    return undefined
+  }
+}
+
+function evalForm(doc, year, category) {
+  if (category === 'ImpotsRevenus') {
+    if (doc.label.match(/^Accusé de réception/)) {
+      return ''
+    } else if (doc.label.match(/^Avis d'impôt/)) {
+      return '1'
+    } else if (doc.label.match(/^1er Avis d'Acompte/)) {
+      return '811'
+    } else if (doc.label.match(/^2e Avis d'Acompte/)) {
+      return '812'
+    } else if (doc.label.match(/^Avis de situation déclarative/)) {
+      return 'SituationDéclarative'
+    } else if (doc.label.match(/^Déclaration en ligne \d{4} de revenus \(/)) {
+      return '2042'
+    } else if (
+      doc.label.match(
+        //eslint-disable-next-line
+          /^Déclaration en ligne 2019 de revenus \: réductions et crédits d'impôt \(/
+      )
+    ) {
+      return '2042RICI'
+    }
+  }
+
+  // Taxe d'habitation
+  if (category === 'TaxeHabitation') {
+    if (doc.label.match(/^Avis de taxe d'habitation/)) {
+      if (year >= 2019) {
+        return ''
+      } else {
+        return 'Primitif'
+      }
+    } else if (doc.label.match(/^Avis échéancier/)) {
+      return 'Echeancier'
+    }
+  }
+
+  // Taxe foncière
+  if (category === 'TaxeFoncière') {
+    if (doc.label.match(/^Avis de taxes foncières/)) {
+      return 'Primitif'
+    }
+  }
+  // Catch unknown form
+  return undefined
 }

--- a/src/fileNamer.js
+++ b/src/fileNamer.js
@@ -175,7 +175,7 @@ function evaluateNewLabel(documents, L, LWP) {
       continue
       //throw 'Type Unknown'
     }
-    doc.form = evalForm(doc, doc.year, doc.category)
+    doc.form = evalForm(doc)
     if (doc.form === undefined) {
       if (LWP) {
         log('info', `New label: ${doc.label}`)
@@ -188,7 +188,7 @@ function evaluateNewLabel(documents, L, LWP) {
 
     // As in old url request year notation change in 2013, there is no 2013 docs,
     // and 2013 docs are named 2012, 2012 -> 2011, ...
-    const apparentYear = (doc.year<2014) ? doc.year-1 : doc.year
+    const apparentYear = doc.year < 2014 ? doc.year - 1 : doc.year
     doc.oldname =
       `${apparentYear}-${doc.category}-${doc.type}` +
       (doc.form === '' ? '-' : `-${doc.form}-`)
@@ -245,8 +245,8 @@ function evalType(doc) {
   }
 }
 
-function evalForm(doc, year, category) {
-  if (category === 'ImpotsRevenus') {
+function evalForm(doc) {
+  if (doc.category === 'ImpotsRevenus') {
     if (doc.label.match(/^Accusé de réception/)) {
       return ''
     } else if (doc.label.match(/^Avis d'impôt/)) {
@@ -257,28 +257,38 @@ function evalForm(doc, year, category) {
       return '812'
     } else if (doc.label.match(/^Avis de situation déclarative/)) {
       return 'SituationDéclarative'
-    } else if (doc.label.match(/^Déclaration en ligne \d{4} de revenus \(/) ||
-               doc.label.match(/^Déclaration \d{4} de revenus$/)) {
+    } else if (
+      doc.label.match(/^Déclaration en ligne \d{4} de revenus \(/) ||
+      doc.label.match(/^Déclaration \d{4} de revenus$/)  //Old not online déclaration
+    ) {
       return '2042'
-    } else if (doc.label.match(/^Déclaration complémentaire en ligne \d{4} de revenus \(/)) {
+    } else if (
+      doc.label.match(
+        /^Déclaration complémentaire en ligne \d{4} de revenus \(/
+      )
+    ) {
       return '2042C'
-    } else if (doc.label.match(
-      //eslint-disable-next-line
+    } else if (
+      doc.label.match(
+        //eslint-disable-next-line
         /^Déclaration en ligne \d{4} de revenus : revenus des professions non salariées \(/
-    )) {
+      )
+    ) {
       return '2042CPRO'
-    } else if (doc.label.match(
-      //eslint-disable-next-line
+    } else if (
+      doc.label.match(
+        //eslint-disable-next-line
         /^Déclaration en ligne \d{4} de revenus \: réductions et crédits d'impôt \(/
-    )) {
+      )
+    ) {
       return '2042RICI'
     }
   }
 
   // Taxe d'habitation
-  if (category === 'TaxeHabitation') {
+  if (doc.category === 'TaxeHabitation') {
     if (doc.label.match(/^Avis de taxe d'habitation/)) {
-      if (year >= 2019) {
+      if (doc.year >= 2019) {
         return ''
       } else {
         return 'Primitif'
@@ -289,14 +299,16 @@ function evalForm(doc, year, category) {
   }
 
   // Taxe foncière
-  if (category === 'TaxeFoncière') {
-    if (doc.label.match(/^Avis de taxes foncières/) && doc.label.match(/suite/)) {
+  if (doc.category === 'TaxeFoncière') {
+    if (
+      doc.label.match(/^Avis de taxes foncières/) &&
+      doc.label.match(/suite/)
+    ) {
       return 'Suite'
-    }
-    else if (doc.label.match(/^Avis de taxes foncières/)) {
+    } else if (doc.label.match(/^Avis de taxes foncières/)) {
       return 'Primitif'
     }
   }
-  // Catch unknown form
+  // Finally, if no doc.category match
   return undefined
 }

--- a/src/index.js
+++ b/src/index.js
@@ -429,7 +429,8 @@ function tryMatching(newDocs, oldDocs, L, LWP) {
     const currentNew = newDocs[currentNewIndex]
     let matches = []
     for (const currentOld of oldDocs) {
-      const regex = new RegExp(`${currentNew.oldname}\\d{14}.pdf`)
+      // Adonis number found before .pdf is 13 or 14 digits in our data
+      const regex = new RegExp(`${currentNew.oldname}\\d{13,14}.pdf`)
       const match = currentOld.filename.match(regex)
       if (match) {
         matches.push(match)
@@ -438,7 +439,14 @@ function tryMatching(newDocs, oldDocs, L, LWP) {
     if (matches.length == 0 || matches.length > 1) {
       mismatch++
       if (L) {
-        log('info', 'multi matches or no match')
+        if (matches.length == 0) {
+          log('info', `!! No match !!`)
+
+        }
+        if (matches.length > 1) {
+          log('info', `!! Multi match !!`)
+        }
+
       }
       if (LWP) {
         log('info', matches)

--- a/src/index.js
+++ b/src/index.js
@@ -441,12 +441,10 @@ function tryMatching(newDocs, oldDocs, L, LWP) {
       if (L) {
         if (matches.length == 0) {
           log('info', `!! No match !!`)
-
         }
         if (matches.length > 1) {
           log('info', `!! Multi match !!`)
         }
-
       }
       if (LWP) {
         log('info', matches)


### PR DESCRIPTION
Add the run of the new function getDocuments
Add two functions exectuted after that.
   **evaluateNewLabel** : will try to return the documents with a 'category', a 'type' and a 'form' and the oldname evaluation.
```
   { year: '2010',
    label: 'Avis d\'impôt 2010 sur les revenus 2009',
    idEnsua: '701AEC0CFREDACTED3620CAA0E324AA4F69F0680961A606BAF356AB80CF0E2424005799ADD21E98F83690311422',
    filename: 'Avis d\'impôt 2010 sur les revenus 2009.pdf',
    fileurl: 'https://cfspart.impots.gouv.fr/enp/ensu/Affichage_Document_PDF?idEnsua=701AEC0CFEB8A6278AREDACTED1A606BAF356AB80CF0E2424005799ADD21E98F83690311422',
    category: 'ImpotsRevenus',
    type: 'Avis',
    form: '1',
    oldname: '2010-ImpotsRevenus-Avis-1-' }
```
   **tryMatching** : a try to match new files oldnames prediction with old files still imported asconfigured poorly verbose now, we can active two variables L and LWP in code to have more logs and more sensitive data locally.

This all process will log warning but never crash the connector.
We can expect a connector end log like this :

```
cozy-konnector-libs: info : Found 51 documents in new pages
cozy-konnector-libs: warn : Form Unknown
cozy-konnector-libs: warn : Form Unknown
cozy-konnector-libs: info : Failed category, type or form evaluation: 2 on 51
cozy-konnector-libs: info : #Failed#: 3.92%
cozy-konnector-libs: info : Trying to match olds and news
cozy-konnector-libs: info : Mistaches: 24 on 51 new docs
cozy-konnector-libs: info : #Mismatch#: 47.06%
```